### PR TITLE
Fixed ship shield planet bug

### DIFF
--- a/core/src/com/game/RocketKrieg.java
+++ b/core/src/com/game/RocketKrieg.java
@@ -172,13 +172,14 @@ public class RocketKrieg implements Screen {
 	/**
 	 * Indicate that player is dead
 	 */
-	public static void playerDead(){
-		if(ship.getShieldCharge()>0) {
+	public static void playerDead(boolean planetCollision){
+		if(ship.getShieldCharge()>0 && !planetCollision) {
 			ship.reduceShieldCharge();
 		} else {
 			ChunkManager.removeEntity(ship);
 			playerState = true;
 			timeElapsed = 0;
+			ship.setPos(ship.position.x,ship.position.y);
 		}
 	}
 

--- a/core/src/com/game/objects/collision/CollisionManager.java
+++ b/core/src/com/game/objects/collision/CollisionManager.java
@@ -42,7 +42,7 @@ public class CollisionManager {
                             entities.remove(i);
                         }
                         collisionEvent(ent1,ent2, entities);
-                        RocketKrieg.playerDead();
+                        RocketKrieg.playerDead(false);
                     } else if((ent1 instanceof Planet && !(ent2 instanceof PlayerSpaceShip)) || (ent2 instanceof Planet && !(ent1 instanceof PlayerSpaceShip))) {
                         //do not explode planets.
                         entities.remove(j);
@@ -70,7 +70,7 @@ public class CollisionManager {
                     } else if((ent1 instanceof Laser && (ent2 instanceof AlienShip || ent2 instanceof AlienShipSpecial)) || (ent2 instanceof Laser && (ent1 instanceof AlienShip || ent1 instanceof AlienShipSpecial))) {
                         //do not let alien laser blow up alien.
                     } else if((ent1 instanceof Planet && ent2 instanceof PlayerSpaceShip) || (ent1 instanceof PlayerSpaceShip && ent2 instanceof Planet)) {
-                        RocketKrieg.playerDead();
+                        RocketKrieg.playerDead(true);
                         if(ent1 instanceof PlayerSpaceShip){
                             entities.remove(i);
                             entities.add(new CollisionEvent(ent1.getPosition().x,ent1.getPosition().y));
@@ -78,6 +78,7 @@ public class CollisionManager {
                             entities.remove(j);
                             entities.add(new CollisionEvent(ent2.getPosition().x,ent2.getPosition().y));
                         }
+
                     } else {
                         //all other collisions.
                         entities.remove(j);

--- a/core/src/com/game/worldGeneration/Tile.java
+++ b/core/src/com/game/worldGeneration/Tile.java
@@ -62,13 +62,13 @@ public class Tile {
         int percent2 = rand.nextInt(100);
 
         //choose random tile texture.
-        if(percent2 <= 94) {
+        if(percent2 <= 97) {
             img = AssetStorage.tile1;
         }
-        else if(percent2 <= 96){
+        else if(percent2 <= 98){
             img = AssetStorage.tile2;
         }
-        else if(percent2 <= 98){
+        else if(percent2 <= 99){
             img = AssetStorage.tile4;
         }
         else {


### PR DESCRIPTION
Om man krockade med en planet och hade sköld så blev det massa explosioner som gjorte att spelet laggade sönder och skeppet satt fast utan att game over skärmen kom upp. Fixat nu